### PR TITLE
set application identity information before first QSettings

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -170,9 +170,17 @@ int main(int argc, char *argv[])
         return 1;
     }
 
+    // Application identification (must be set before OptionsModel is initialized,
+    // as it is used to locate QSettings)
+    app.setOrganizationName("Bitcoin");
+    app.setOrganizationDomain("bitcoin.org");
+    if(GetBoolArg("-testnet")) // Separate UI settings for testnet
+        app.setApplicationName("Bitcoin-Qt-testnet");
+    else
+        app.setApplicationName("Bitcoin-Qt");
+
     // ... then GUI settings:
     OptionsModel optionsModel;
-
 
     // Load language files for system locale:
     // - First load the translator for the base language, without territory
@@ -197,10 +205,6 @@ int main(int argc, char *argv[])
     translator.load(":/translations/"+lang_territory);
     if (!translator.isEmpty())
         app.installTranslator(&translator);
-
-    app.setOrganizationName("Bitcoin");
-    app.setOrganizationDomain("bitcoin.org");
-    app.setApplicationName(QApplication::translate("main", "Bitcoin-Qt"));
 
     QSplashScreen splash(QPixmap(":/images/splash"), 0);
     splash.show();

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -10,9 +10,9 @@ OptionsModel::OptionsModel(QObject *parent) :
 {
     QSettings settings;
 
-    if (!settings.contains("import_finished"))
+    if (!settings.contains("bImportFinished"))
     {
-        settings.setValue("import_finished", true);
+        settings.setValue("bImportFinished", true);
 
         // Move settings from old wallet.dat (if any):
         CWalletDB walletdb("wallet.dat");


### PR DESCRIPTION
Fix the following:
- Application identity information (setOrganizationName / setOrganizationDomain / setApplicationName) that is used to choose the qsettings location should probably take into account testnet / normalnet, so that those settings don't overlap
- The OptionsModel (which uses QSettings) is constructed before setting the app identity information. I don't think that will work.
- setApplicationName currently depends on the language, as it is run through the translator. If this means that the settings location depends on the language, people will lose their settings when changing language.
- "import_finished" -> "bImportFinished"

I've tested it a bit and at least the GUI settings are remembered. 

What doesn't work yet, is the initial conversion of wallet.dat, it gives an error:

```
************************
EXCEPTION: NSt8ios_base7failureE        
CAutoFile::read : end of file       
bitcoin in Runaway exception       

terminate called after throwing an instance of 'std::ios_base::failure'
  what():  CAutoFile::read : end of file
The program has unexpectedly finished.
/store/orion/projects/bitcoin/bitcoin-qt-build-desktop/bitcoin-qt exited with code 0
```

I don't think the wallet database system works before AppInit2 initialization? We must somehow move this migration to a later point.
