### PR TITLE
Track fees being paid to get confirmed within N blocks.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1799,11 +1799,7 @@ bool SetBestChain(CValidationState &state, CBlockIndex* pindexNew)
             LogPrintf("- Connect: %.2fms\n", (GetTimeMicros() - nStart) * 0.001);
 
         // Accepted into block, means remove from memory pool
-        BOOST_FOREACH(const CTransaction& tx, block.vtx)
-        {
-            mempool.remove(tx, false, pindex->nHeight-1);
-            mempool.removeConflicts(tx);
-        }
+        mempool.removeForBlock(block.vtx, pindex->nHeight-1);
     }
 
     // Flush changes to global coin state

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -13,6 +13,7 @@
 static const unsigned int MEMPOOL_HEIGHT = 0x7FFFFFFF;
 
 class CMinerPolicyEstimator; // Internal class used for estimatefee functionality
+class CMinerPolicyEstimator2;
 
 /*
  * CTxMemPool stores these:
@@ -57,6 +58,7 @@ private:
     bool fSanityCheck; // Normally false, true if -checkmempool or -regtest
     unsigned int nTransactionsUpdated;
     CMinerPolicyEstimator* minerPolicyEstimator; // For estimating transaction fees
+    CMinerPolicyEstimator2* minerPolicyEstimator2;
 
     void writeEntry(CAutoFile& file, const uint256& txid, std::set<uint256>& alreadyWritten) const;
 
@@ -80,11 +82,14 @@ public:
     bool addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry);
     bool remove(const CTransaction &tx, bool fRecursive = false, unsigned int nBlockHeight = 0);
     bool removeConflicts(const CTransaction &tx);
+    void removeForBlock(const std::vector<CTransaction>& vtx, unsigned int nBlockHeight);
     void clear();
     void queryHashes(std::vector<uint256>& vtxid);
     void pruneSpent(const uint256& hash, CCoins &coins);
     double estimateFreePriority(double dPriorityMedian, bool fUseHardCoded=false);
     double estimateFee(double dFeeMedian, bool fUseHardCoded=false); // Returns satoshi-per-byte estimate
+    double estimatePriorityToConfirmWithin(int nBlocks);
+    double estimateFeeToConfirmWithin(int nBlocks);
     unsigned int GetTransactionsUpdated() const;
     void AddTransactionsUpdated(unsigned int n);
 


### PR DESCRIPTION
Merry Christmas! :) 

What do you think of this? I find the output easier to understand and reason about. Will leave it running for a while. It converged on something slightly above min fee for the 10th percentile pretty fast. However lots of people are paying above the min fee currently so the median/50th percentile can end up quite high, especially if you start your node during a time when no block was found for a while so there's a backlog.

For me right now the 10th percentile to confirm within 3 blocks is the min fee. Others are higher :( What this tells me is we need higher blocks .... but at least with a "%ile of N blocks" data source we can think about making a (crappy) UI for letting users pick how fast they'd like a confirm. Hopefully any such UI would be a temporary thing to get us through the scaling issues over the next year, until eventually all "normal" spends confirm as fast as possible.

I'll work on a  few unit tests too.
